### PR TITLE
Close file and writer in correct order

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -110,10 +110,10 @@ func (proj *Project) Zip(zipPath string, private bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to create archive '%s'", zipPath)
 	}
+	defer zipFile.Close()
 
 	zipWriter := zip.NewWriter(zipFile)
 	defer zipWriter.Close()
-	defer zipFile.Close()
 
 	zipInfo, _ := os.Stat(zipPath)
 


### PR DESCRIPTION
Defer statements are pushed onto a stack. The current ordering of deferred statements within the `Zip` call ensure the file is closed before the writer is flushed. The resulting zip file will not contain any content and will not work correctly.