### PR TITLE
Decouple Proxy Implementations

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/glesica/farnsworth/project"
+	_ "github.com/glesica/farnsworth/proxy/go"
+	_ "github.com/glesica/farnsworth/proxy/java"
 )
 
 func main() {

--- a/project/project.go
+++ b/project/project.go
@@ -23,14 +23,14 @@ type Project struct {
 
 // Load creates a new project from a path.
 func Load(projectPath string) (*Project, error) {
-	absProjectPath, absProjectPathErr := filepath.Abs(projectPath)
-	if absProjectPathErr != nil {
+	absProjectPath, err := filepath.Abs(projectPath)
+	if err != nil {
 		return nil, fmt.Errorf("failed to convert '%s' to absolute path", projectPath)
 	}
 
 	projectBaseName := filepath.Base(absProjectPath)
 
-	proxy, err := proxy.GetProxy(projectPath)
+	proxy, err := proxy.Get(projectPath)
 	if err != nil {
 		return nil, err
 	}
@@ -117,8 +117,8 @@ func (proj *Project) Zip(zipPath string, private bool) error {
 
 	zipInfo, _ := os.Stat(zipPath)
 
-	filepath.Walk(proj.path, func(filePath string, fileInfo os.FileInfo, walkErr error) error {
-		if walkErr != nil {
+	filepath.Walk(proj.path, func(filePath string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
 			return fmt.Errorf("failed to stat '%s', skipping", filePath)
 		}
 

--- a/proxy/go/golang.go
+++ b/proxy/go/golang.go
@@ -4,7 +4,13 @@ import (
 	"io/ioutil"
 	"regexp"
 	"strings"
+
+	"github.com/glesica/farnsworth/proxy"
 )
+
+func init() {
+	proxy.Register(Factory, IsValid)
+}
 
 // IsValid indicates whether the given project root is a valid project of this type.
 func IsValid(path string) bool {
@@ -24,20 +30,20 @@ func IsValid(path string) bool {
 }
 
 // Factory returns an instance of the Proxy.
-func Factory() *Proxy {
-	return &Proxy{}
+func Factory() proxy.Proxy {
+	return &golang{}
 }
 
-// Proxy is a project proxy for a Gradle-based Java project.
-type Proxy struct{}
+// golang is a project proxy for a Gradle-based Java project.
+type golang struct{}
 
 // Name is the unique name of the project proxy.
-func (proxy *Proxy) Name() string {
+func (proxy *golang) Name() string {
 	return "golang"
 }
 
 // IsHideLine indicates whether the given line begins a hidden block.
-func (proxy *Proxy) IsHideLine(line string) bool {
+func (proxy *golang) IsHideLine(line string) bool {
 	matched, matchedErr := regexp.MatchString(`^\s*//\+\+\s*hide\s*$`, line)
 	if matchedErr != nil {
 		// Dangerous, but meh.
@@ -47,7 +53,7 @@ func (proxy *Proxy) IsHideLine(line string) bool {
 }
 
 // IsStopLine indicates whether the given line ends a block.
-func (proxy *Proxy) IsStopLine(line string) bool {
+func (proxy *golang) IsStopLine(line string) bool {
 	matched, matchedErr := regexp.MatchString(`^\s*//\+\+\s*stop\s*$`, line)
 	if matchedErr != nil {
 		// Dangerous, but meh.
@@ -57,6 +63,6 @@ func (proxy *Proxy) IsStopLine(line string) bool {
 }
 
 // ShouldMerge indicates whether the given path should be merged.
-func (proxy *Proxy) ShouldMerge(path string, content []byte) bool {
+func (proxy *golang) ShouldMerge(path string, content []byte) bool {
 	return strings.HasSuffix(path, "_test.go")
 }

--- a/proxy/go/golang_test.go
+++ b/proxy/go/golang_test.go
@@ -4,7 +4,7 @@ import "testing"
 import "fmt"
 
 func TestName(t *testing.T) {
-	proxy := Proxy{}
+	proxy := golang{}
 	name := proxy.Name()
 	if name != "golang" {
 		t.Errorf("Expected Name() to return 'golang', found '%s'", name)
@@ -49,7 +49,7 @@ func getFailingTags(label string) []string {
 }
 
 func TestIsHideLine(t *testing.T) {
-	proxy := Proxy{}
+	proxy := golang{}
 	// True
 	for _, line := range getPassingTags("hide") {
 		t.Run(fmt.Sprintf("line='%s'", line), func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestIsHideLine(t *testing.T) {
 }
 
 func TestIsStopLine(t *testing.T) {
-	proxy := Proxy{}
+	proxy := golang{}
 	// True
 	for _, line := range getPassingTags("stop") {
 		t.Run(fmt.Sprintf("line='%s'", line), func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestIsStopLine(t *testing.T) {
 }
 
 func TestShouldMerge(t *testing.T) {
-	proxy := Proxy{}
+	proxy := golang{}
 	// True
 	for _, path := range []string{
 		"module_test.go",

--- a/proxy/java/java.go
+++ b/proxy/java/java.go
@@ -1,8 +1,16 @@
 package java
 
-import "io/ioutil"
-import "regexp"
-import "strings"
+import (
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"github.com/glesica/farnsworth/proxy"
+)
+
+func init() {
+	proxy.Register(Factory, IsValid)
+}
 
 // IsValid indicates whether the given project root is a valid project of this type.
 func IsValid(path string) bool {
@@ -21,20 +29,20 @@ func IsValid(path string) bool {
 }
 
 // Factory returns an instance of the Proxy.
-func Factory() *Proxy {
-	return &Proxy{}
+func Factory() proxy.Proxy {
+	return &java{}
 }
 
-// Proxy is a project proxy for a Gradle-based Java project.
-type Proxy struct{}
+// java is a project proxy for a Gradle-based Java project.
+type java struct{}
 
 // Name is the unique name of the project proxy.
-func (proxy *Proxy) Name() string {
+func (proxy *java) Name() string {
 	return "java"
 }
 
 // IsHideLine indicates whether the given line begins a hidden block.
-func (proxy *Proxy) IsHideLine(line string) bool {
+func (proxy *java) IsHideLine(line string) bool {
 	matched, matchedErr := regexp.MatchString(`^\s*//\+\+\s*hide\s*$`, line)
 	if matchedErr != nil {
 		// Dangerous, but meh.
@@ -44,7 +52,7 @@ func (proxy *Proxy) IsHideLine(line string) bool {
 }
 
 // IsStopLine indicates whether the given line ends a block.
-func (proxy *Proxy) IsStopLine(line string) bool {
+func (proxy *java) IsStopLine(line string) bool {
 	matched, matchedErr := regexp.MatchString(`^\s*//\+\+\s*stop\s*$`, line)
 	if matchedErr != nil {
 		// Dangerous, but meh.
@@ -54,6 +62,6 @@ func (proxy *Proxy) IsStopLine(line string) bool {
 }
 
 // ShouldMerge indicates whether the given path should be merged.
-func (proxy *Proxy) ShouldMerge(path string, content []byte) bool {
+func (proxy *java) ShouldMerge(path string, content []byte) bool {
 	return strings.Contains(path, "src/test")
 }

--- a/proxy/java/java_test.go
+++ b/proxy/java/java_test.go
@@ -4,7 +4,7 @@ import "testing"
 import "fmt"
 
 func TestName(t *testing.T) {
-	proxy := Proxy{}
+	proxy := java{}
 	name := proxy.Name()
 	if name != "java" {
 		t.Errorf("Expected Name() to return 'java', found '%s'", name)
@@ -49,7 +49,7 @@ func getFailingTags(label string) []string {
 }
 
 func TestIsHideLine(t *testing.T) {
-	proxy := Proxy{}
+	proxy := java{}
 	// True
 	for _, line := range getPassingTags("hide") {
 		t.Run(fmt.Sprintf("line='%s'", line), func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestIsHideLine(t *testing.T) {
 }
 
 func TestIsStopLine(t *testing.T) {
-	proxy := Proxy{}
+	proxy := java{}
 	// True
 	for _, line := range getPassingTags("stop") {
 		t.Run(fmt.Sprintf("line='%s'", line), func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestIsStopLine(t *testing.T) {
 }
 
 func TestShouldMerge(t *testing.T) {
-	proxy := Proxy{}
+	proxy := java{}
 	// True
 	for _, path := range []string{
 		"src/test/test.java",


### PR DESCRIPTION
The `Proxy` interface is defined but is implicitly utilized. A `Register` function is provided that allows any library to implement the `Proxy` interface and have it included when trying to obtain a proxy when dealing with a project. Each proxy implementation is now private and the package registers it as a valid proxy. The main app imports each proxy implementation to be included when the application is run.